### PR TITLE
Action dates

### DIFF
--- a/campaignForm/action/ActionFormInfoLabel.scss
+++ b/campaignForm/action/ActionFormInfoLabel.scss
@@ -9,6 +9,9 @@
     &.location:before {
         @include icon($fa-var-map-marker);
     }
+    &.date:before {
+        @include icon($fa-var-calendar);
+    }
     &.time:before {
         @include icon($fa-var-clock-o);
     }

--- a/campaignForm/action/ActionInfoSection.jsx
+++ b/campaignForm/action/ActionInfoSection.jsx
@@ -83,7 +83,9 @@ export default class ActionInfoSection extends React.Component {
                         label={ campaign }/>
                     </a>
                     <ActionFormInfoLabel className="location"
-                    label={ location }/>
+                        label={ location }/>
+                    <ActionFormInfoLabel className="date"
+                        label={ startTime.format('{yyyy}-{MM}-{dd}') }/>
                     <ActionFormInfoLabel className="time"
                         label={ timeLabel }/>
 

--- a/campaignForm/action/MultiLocationActionForm.jsx
+++ b/campaignForm/action/MultiLocationActionForm.jsx
@@ -90,6 +90,8 @@ export default class MultiLocationActionForm extends React.Component {
                 { currentNeed }
                 <ActionFormInfoLabel className="campaign"
                     label={ actions[0].getIn(['campaign', 'title']) }/>
+                <ActionFormInfoLabel className="date"
+                    label={ startTime.format('{yyyy}-{MM}-{dd}') }/>
                 <ActionFormInfoLabel className="time"
                     label={ timeLabel }/>
                 { content }

--- a/campaignForm/action/MultiShiftActionForm.jsx
+++ b/campaignForm/action/MultiShiftActionForm.jsx
@@ -24,6 +24,7 @@ export default class MultiShiftActionForm extends React.Component {
 
     render() {
         let actions = this.props.actions;
+        let firstStartTime = null;
 
         let orgItem = this.props.orgList.find(org =>
                 org.get('id') == actions[0].get('org_id'));
@@ -37,6 +38,10 @@ export default class MultiShiftActionForm extends React.Component {
                 { fromUTC: true, setUTC: true });
             let endTime = Date.create(action.get('end_time'),
                 { fromUTC: true, setUTC: true });
+
+            if (!firstStartTime) {
+                firstStartTime = startTime;
+            }
 
             // TODO: Find nice way to localize this
             let timeLabel = startTime.format('{HH}:{mm}')
@@ -83,6 +88,8 @@ export default class MultiShiftActionForm extends React.Component {
                     label={ actions[0].getIn(['campaign', 'title']) }/>
                 <ActionFormInfoLabel className="location"
                         label={ actions[0].getIn(['location', 'title']) }/>
+                <ActionFormInfoLabel className="date"
+                    label={ firstStartTime.format('{yyyy}-{MM}-{dd}') }/>
                 <ul>
                     { shiftItems }
                 </ul>

--- a/campaignForm/action/SingleActionForm.jsx
+++ b/campaignForm/action/SingleActionForm.jsx
@@ -74,6 +74,8 @@ export default class SingleActionForm extends React.Component {
                     label={ campaign }/>
                 <ActionFormInfoLabel className="location"
                     label={ location }/>
+                <ActionFormInfoLabel className="date"
+                    label={ startTime.format('{yyyy}-{MM}-{dd}') }/>
                 <ActionFormInfoLabel className="time"
                     label={ timeLabel }/>
 


### PR DESCRIPTION
This PR adds dates to action forms and the action info section. When there are a lot of actions, the date headers that group actions together don't really suffice. After scrolling a few hundred pixels past the last header, it's hard to remember the relevant date.

![image](https://user-images.githubusercontent.com/550212/41862862-5ce6055a-78a5-11e8-8139-19302aa1fddd.png)
