### PR TITLE
CampaignForm: add activityFilter prop, default ON

### DIFF
--- a/campaignForm/CampaignForm.jsx
+++ b/campaignForm/CampaignForm.jsx
@@ -21,6 +21,7 @@ export default class CampaignForm extends React.Component {
     static propTypes = {
         forceNeeded: PropTypes.bool,
         needFilterEnabled: PropTypes.bool,
+        needActivityFilter: PropTypes.bool,
         redirPath: PropTypes.string,
         actionList: PropTypes.complexList.isRequired,
         userActionList: PropTypes.complexList.isRequired,
@@ -157,7 +158,7 @@ export default class CampaignForm extends React.Component {
                     activities[aKey].actionCount++;
                 });
 
-                if (Object.keys(activities).length) {
+                if (this.props.needActivityFilter !== false && Object.keys(activities).length) {
                     activityFilter = (
                         <ActionFilterSummary
                             selectedValues={ this.state.filterActivities }

--- a/campaignForm/CampaignForm.jsx
+++ b/campaignForm/CampaignForm.jsx
@@ -21,7 +21,7 @@ export default class CampaignForm extends React.Component {
     static propTypes = {
         forceNeeded: PropTypes.bool,
         needFilterEnabled: PropTypes.bool,
-        needActivityFilter: PropTypes.bool,
+        activityFilter: PropTypes.bool,
         redirPath: PropTypes.string,
         actionList: PropTypes.complexList.isRequired,
         userActionList: PropTypes.complexList.isRequired,
@@ -158,7 +158,7 @@ export default class CampaignForm extends React.Component {
                     activities[aKey].actionCount++;
                 });
 
-                if (this.props.needActivityFilter !== false && Object.keys(activities).length) {
+                if (this.props.activityFilter !== false && Object.keys(activities).length) {
                     activityFilter = (
                         <ActionFilterSummary
                             selectedValues={ this.state.filterActivities }


### PR DESCRIPTION
This PR adds a new property to the CampaignForm: "Do we need to include the activity filter widget?"

Its value is default true.

See https://github.com/zetkin/www.zetk.in/issues/246