### PR TITLE
Add margin-right to .SingleActionForm-info to prevent overlap with arrow

### DIFF
--- a/campaignForm/action/SingleActionForm.scss
+++ b/campaignForm/action/SingleActionForm.scss
@@ -28,6 +28,7 @@
         text-overflow: ellipsis;
         max-height: 3em;
         transition: max-height 0.5s;
+        margin-right: 1.5em;
 
         &:after {
             @include icon($fa-var-arrow-right);


### PR DESCRIPTION
Resolves zetkin/www.zetk.in#278