### PR TITLE
Automatic survey field values from personal data

### DIFF
--- a/surveyForm/SurveyElement.jsx
+++ b/surveyForm/SurveyElement.jsx
@@ -30,6 +30,7 @@ export default class SurveyElement extends React.Component {
                     question={ element.get('question') }
                     response={ this.props.response }
                     onResponse={ this.props.onResponse }
+                    onInitialValue={ this.props.onInitialValue }
                     />
             );
         }

--- a/surveyForm/SurveyForm.jsx
+++ b/surveyForm/SurveyForm.jsx
@@ -30,6 +30,9 @@ export default class SurveyForm extends React.Component {
             valid: true,
             privacyApproved: false,
         };
+
+        // Temporary store for initial values
+        this.pendingValues = [];
     }
 
     render() {
@@ -46,6 +49,7 @@ export default class SurveyForm extends React.Component {
             return (
                 <SurveyElement key={ id }
                     onResponse={ this.onResponse.bind(this, id) }
+                    onInitialValue={ this.onInitialValue.bind(this, id) }
                     response={ response }
                     element={ elem }
                     />
@@ -138,7 +142,24 @@ export default class SurveyForm extends React.Component {
 
     onResponse(elemId, response) {
         if (this.props.onResponse) {
+            if (this.pendingValues.length) {
+                // If there are any pending initial values to set, do it now
+                for (const pending of this.pendingValues) {
+                    this.props.onResponse(pending.id, pending.value);
+                }
+                this.pendingValues = []
+            }
+
             this.props.onResponse(elemId, response);
         }
+    }
+    
+    /* 
+     * Store initial values locally until an actual response is input.
+     * This is because call considers wheter to submit a survey depending on the state of the survey,
+     * and we don't want the survey to be sumitted if the user did not take any action.
+     */
+    onInitialValue(elemId, value) {
+        this.pendingValues.push({ id: elemId, value: value })
     }
 }

--- a/surveyForm/SurveyQuestion.jsx
+++ b/surveyForm/SurveyQuestion.jsx
@@ -43,7 +43,8 @@ export default class SurveyQuestion extends React.Component {
             responseWidget = (
                 <PersonFieldWidget name={ name } question={ question }
                     response={ this.props.response }
-                    onChange={ this.onChange.bind(this) }/>
+                    onChange={ this.onChange.bind(this) }
+                    onInitialValue={ this.props.onInitialValue } />
             );
         }
 

--- a/surveyForm/SurveyQuestion.jsx
+++ b/surveyForm/SurveyQuestion.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from '../../utils/PropTypes';
 import TextWidget from './widgets/TextWidget';
 import OptionsWidget from './widgets/OptionsWidget';
+import PersonFieldWidget from './widgets/PersonFieldWidget';
 
 
 export default class SurveyQuestion extends React.Component {
@@ -35,6 +36,12 @@ export default class SurveyQuestion extends React.Component {
         else if (question.get('response_type') == 'text') {
             responseWidget = (
                 <TextWidget name={ name } question={ question }
+                    response={ this.props.response }
+                    onChange={ this.onChange.bind(this) }/>
+            );
+        } else if (question.get('response_type') == 'person_field') {
+            responseWidget = (
+                <PersonFieldWidget name={ name } question={ question }
                     response={ this.props.response }
                     onChange={ this.onChange.bind(this) }/>
             );

--- a/surveyForm/widgets/PersonFieldWidget.jsx
+++ b/surveyForm/widgets/PersonFieldWidget.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { connect } from 'react-redux';
+
+import PropTypes from '../../../utils/PropTypes';
+import TextWidget from './TextWidget';
+
+
+const mapStateToProps = state => {
+    if (state.get('calls')) {
+        // This common library is used by both www and call, only import the lanes store if in call.
+        const lanes =  require('../../../store/lanes');
+
+        return {
+            calls: state.get('calls'),
+            lane: lanes.selectedLane(state),
+        }
+    } else {
+        return {};
+    }
+};
+
+@connect(mapStateToProps)
+export default class PersonFieldWidget extends React.Component {
+    static propTypes = {
+        name: PropTypes.string.isRequired,
+        question: PropTypes.map.isRequired,
+        onChange: PropTypes.func,
+        response: PropTypes.map,
+    };
+
+    render() {
+        let initialValue;
+        // This only applies to when the survey is used in a call
+        if (this.props.calls && this.props.lane) {
+            const callId = this.props.lane.get('callId')
+            const target = this.props.calls.getIn(['callList', 'items', callId, 'target'])
+            const personField = this.props.question.getIn(['response_config', 'person_field'])
+
+            if (typeof(target.get(personField)) == 'string') {
+                // If personField is one of the native fields
+                initialValue = target.get(personField)
+            } else if (target.get('person_fields')) {
+                // Note that this can only happen if the server has returned the person_fields array.
+                // The call assignment may have to be configured to expose_full_details=true
+
+                // Check for the personField in the custom fields
+                const field = target.get('person_fields').find(f => f.get('slug') == personField);
+                if (field) {
+                    initialValue = field.get('value')
+                }
+            }
+        }
+
+        return (
+            <TextWidget
+                name={ this.props.name }
+                question={ this.props.question }
+                onChange={ this.props.onChange }
+                response={ this.props.response }
+                initialValue={ initialValue } />
+        );
+    }
+}

--- a/surveyForm/widgets/PersonFieldWidget.jsx
+++ b/surveyForm/widgets/PersonFieldWidget.jsx
@@ -25,12 +25,15 @@ export default class PersonFieldWidget extends React.Component {
         name: PropTypes.string.isRequired,
         question: PropTypes.map.isRequired,
         onChange: PropTypes.func,
+        onInitialValue: PropTypes.func,
         response: PropTypes.map,
     };
 
-    render() {
-        let initialValue;
+    constructor(props) {
+        super(props);
+
         // This only applies to when the survey is used in a call
+        let initialValue;
         if (this.props.calls && this.props.lane) {
             const callId = this.props.lane.get('callId')
             const target = this.props.calls.getIn(['callList', 'items', callId, 'target'])
@@ -46,18 +49,32 @@ export default class PersonFieldWidget extends React.Component {
                 // Check for the personField in the custom fields
                 const field = target.get('person_fields').find(f => f.get('slug') == personField);
                 if (field) {
-                    initialValue = field.get('value')
+                    initialValue = field.get('value');
                 }
             }
         }
 
+        this.state = {
+            initialValue: initialValue,
+        }
+
+        if (initialValue) {
+            this.props.onInitialValue({ response: initialValue });
+        }
+    }
+
+    componentWillMount() {
+     
+    }
+
+    render() { 
         return (
             <TextWidget
                 name={ this.props.name }
                 question={ this.props.question }
                 onChange={ this.props.onChange }
                 response={ this.props.response }
-                initialValue={ initialValue } />
+                initialValue={ this.state.initialValue } />
         );
     }
 }

--- a/surveyForm/widgets/TextWidget.jsx
+++ b/surveyForm/widgets/TextWidget.jsx
@@ -9,13 +9,15 @@ export default class TextWidget extends React.Component {
         question: PropTypes.map.isRequired,
         onChange: PropTypes.func,
         response: PropTypes.map,
+        initialValue: PropTypes.string,
     };
 
     constructor(props) {
         super(props);
 
+        const initialValue = this.props.initialValue || '';
         this.state = {
-            value: props.response? props.response.get('response') : '',
+            value: props.response? props.response.get('response') : initialValue,
         };
     }
 

--- a/surveyForm/widgets/TextWidget.jsx
+++ b/surveyForm/widgets/TextWidget.jsx
@@ -16,6 +16,7 @@ export default class TextWidget extends React.Component {
         super(props);
 
         const initialValue = this.props.initialValue || '';
+
         this.state = {
             value: props.response? props.response.get('response') : initialValue,
         };


### PR DESCRIPTION
If in call mode and where a `person_field` type field has been added to a survey, auto-populate the field from the specified person object data.

Note that for this to work, a survey has to have a `person_field` type question, and if data from a custom field is desired, the call assignment has to be set to `expose_target_details=true`.